### PR TITLE
debug: empty captcha image on Ubuntu 20.04 LTS/.NET Core 3.1/libgdipl…

### DIFF
--- a/src/DNTCaptcha.Core/DNTCaptcha.Core.csproj
+++ b/src/DNTCaptcha.Core/DNTCaptcha.Core.csproj
@@ -17,6 +17,8 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <Version>2.9.1</Version>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <PlatformTarget>anycpu</PlatformTarget>

--- a/src/DNTCaptcha.Core/Providers/CaptchaImageProvider.cs
+++ b/src/DNTCaptcha.Core/Providers/CaptchaImageProvider.cs
@@ -157,7 +157,7 @@ namespace DNTCaptcha.Core.Providers
 
         private void distortImage(int height, int width, Bitmap pic)
         {
-            using (var copy = (Bitmap)pic.Clone())
+            using (var copy = new Bitmap(pic))
             {
                 double distort = _randomNumberProvider.Next(1, 6) * (_randomNumberProvider.Next(10) == 1 ? 1 : -1);
                 for (int y = 0; y < height; y++)


### PR DESCRIPTION
debug: empty captcha image on Ubuntu 20.04 LTS/.NET Core 3.1/libgdiplus-focal 6.0.4
