### PR TITLE
Removed static dir=ltr to support rtl

### DIFF
--- a/src/DNTCaptcha.Core/DNTCaptchaTagHelper.cs
+++ b/src/DNTCaptcha.Core/DNTCaptchaTagHelper.cs
@@ -292,7 +292,6 @@ namespace DNTCaptcha.Core
             textInput.Attributes.Add("required", "required");
             textInput.Attributes.Add("data-required-msg", ValidationErrorMessage);
             textInput.Attributes.Add("placeholder", Placeholder);
-            textInput.Attributes.Add("dir", "ltr");
             textInput.Attributes.Add("type", "text");
             textInput.Attributes.Add("value", "");
             return textInput;


### PR DESCRIPTION
ltr is default, removing this static value so it's up to the browser/developer to set the dir