### PR TITLE
removed outdated instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,12 +220,6 @@ namespace DNTCaptcha.TestWebApp.Controllers
         }
 ```
 
-- If you use `Swagger` make sure to install [Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting](https://github.com/chsakell/Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting) Nuget Package and add it like so:
-
-```csharp
-services.AddSwaggerGenWithConventionalRoutes();
-```
-
 ## How to choose a correct storage mode
 
 If your environment is distributed and you are using a `Session (UseSessionStorageProvider())`


### PR DESCRIPTION
this instruction was used to config conventional routing + routing template for swagger.
now that openAPI enforces attributes, we can't use it. so i removed it as it was redundant.