### PR TITLE
fix: changing route template name issue

### DIFF
--- a/src/DNTCaptcha.Core/ControllerRoutingConvention.cs
+++ b/src/DNTCaptcha.Core/ControllerRoutingConvention.cs
@@ -26,17 +26,6 @@ public class ControllerRoutingConvention(Type controllerType, string? routeTempl
         }
 
         ApplyNewRouteDynamically(controller);
-        ApplyNewNameDynamically(controller);
-    }
-
-    private void ApplyNewNameDynamically(ControllerModel controllerModel)
-    {
-        if (string.IsNullOrEmpty(nameTemplate))
-        {
-            return;
-        }
-
-        controllerModel.ControllerName = nameTemplate;
     }
 
     private void ApplyNewRouteDynamically(ControllerModel controllerModel)
@@ -46,11 +35,12 @@ public class ControllerRoutingConvention(Type controllerType, string? routeTempl
             return;
         }
 
-        foreach (var selector in controllerModel.Selectors)
+        foreach (var action in controllerModel.Actions)
         {
-            selector.AttributeRouteModel = new AttributeRouteModel
+            action.Selectors[0].AttributeRouteModel = new AttributeRouteModel
             {
-                Template = routeTemplate
+                Template = routeTemplate,
+                Name = $"{nameTemplate}-{action.ActionName}"
             };
         }
     }

--- a/src/DNTCaptcha.Core/DNTCaptchaImageController.cs
+++ b/src/DNTCaptcha.Core/DNTCaptchaImageController.cs
@@ -81,8 +81,8 @@ public class DNTCaptchaImageController(
     ///     Refresh the captcha
     /// </summary>
     [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true, Duration = 0)]
-    [HttpGet(template: "[action]")]
-    [HttpPost(template: "[action]")]
+    [HttpGet]
+    [HttpPost]
     public IActionResult Refresh(string data)
     {
         try
@@ -177,8 +177,8 @@ public class DNTCaptchaImageController(
     ///     Creates the captcha image.
     /// </summary>
     [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true, Duration = 0)]
-    [HttpGet(template: "[action]")]
-    [HttpPost(template: "[action]")]
+    [HttpGet]
+    [HttpPost]
     public IActionResult Show(string data)
     {
         try

--- a/src/DNTCaptcha.Core/DNTCaptchaOptions.cs
+++ b/src/DNTCaptcha.Core/DNTCaptchaOptions.cs
@@ -361,6 +361,11 @@ public class DNTCaptchaOptions
     /// <returns></returns>
     public DNTCaptchaOptions WithCaptchaImageControllerRouteTemplate(string template)
     {
+        if (string.IsNullOrWhiteSpace(template) || !template.Contains("[action]", StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Route template must contain the '[action]' placeholder.", nameof(template));
+        }
+
         CaptchaImageControllerRouteTemplate = template;
 
         return this;

--- a/src/DNTCaptcha.TestWebApp/Program.cs
+++ b/src/DNTCaptcha.TestWebApp/Program.cs
@@ -59,6 +59,8 @@ void ConfigureServices(IServiceCollection services, IWebHostEnvironment env)
                 10) // for .NET 7x, Also you need to call app.UseRateLimiter() after calling app.UseRouting().
             .ShowThousandsSeparators(false).WithNoise(0.015f, 0.015f, 1, 0.0f)
             .WithEncryptionKey("This is my secure key!").WithNonceKey("NETESCAPADES_NONCE")
+            .WithCaptchaImageControllerNameTemplate("my-custom-captcha")
+            // The route template must contain [action] placeholder
             .WithCaptchaImageControllerRouteTemplate("my-custom-captcha/[action]")
             .InputNames( // This is optional. Change it if you don't like the default names.
                 new DNTCaptchaComponent


### PR DESCRIPTION
When I changed `CaptchaImageControllerNameTemplate` to a value different than "DNTCaptchaImage" (the controller name), then the captcha did not load (in TestWebApp). So I fixed it in ControllerRoutingConvention.

Also, I have applied some changes to prevent the action name from appearing two times in URLs: "DNTCaptchaImage/Show/Show"

The route template name (CaptchaImageControllerNameTemplate) is not required, and we can remove it because we have used `IUrlHelper.Action` to generate URL everywhere, but I have not removed it because it could be used when someone wants to generate a URL of `DNTCaptchaImageController` by using `IUrlHelper.RouteUrl`.